### PR TITLE
Add ProgressMeter to Requirements

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,3 +13,4 @@ MultivariateStats
 DataFrames
 AxisArrays
 RecursiveArrayTools
+ProgressMeter


### PR DESCRIPTION
latest changes seem to use ProgressMeter... if not installed manually this leads to an error: Progress not defined.  May be also be needed in the dependencies...