### PR TITLE
WIP: Add proj keyword to exportcube, to add the CRS

### DIFF
--- a/src/Proc/CubeIO.jl
+++ b/src/Proc/CubeIO.jl
@@ -102,7 +102,7 @@ function exportcube(r::AbstractCubeData,filename::String;priorities = Dict("LON"
   isplit isa Nothing && (isplit=length(dl)+1)
   incubes = InDims(ax_cont[1:(isplit-1)]...)
   cont_loop = Dict(ii=>axname(ax_cont[ii]) for ii in isplit:length(ax_cont))
-  mapCube(writefun,r,length(ax_cont),cont_loop,filename,indims=incubes,include_loopvars=true,ispar=false,max_cache=5e7)
+  mapCube(writefun,r,length(ax_cont),cont_loop,filename,indims=incubes,include_loopvars=true,ispar=false,max_cache=5e8)
   NetCDF.close(file)
   nothing
 end

--- a/src/Proc/CubeIO.jl
+++ b/src/Proc/CubeIO.jl
@@ -148,4 +148,15 @@ AXIS[\"Easting\",EAST],
 AXIS[\"Northing\",NORTH],
 AUTHORITY[\"EPSG\",\"32629\"]]",
 "GeoTransform" => "722576.2320803495 20 0 4115483.464603715 0 -20 ")
+
+global const epsg4326=Dict(
+  "grid_mapping_name" => "latitude_longitude",
+  "long_name" => "CRS definition",
+  "longitude_of_prime_meridian" => 0.,
+  "semi_major_axis" => 6378137.,
+  "inverse_flattening" => 298.257223563,
+  "spatial_ref" => "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]]",
+  "GeoTransform" => "-98.68712696894481 0.0001796630568239077 0 20.69179551612753 0 -0.0001796630568239077 "
+)
+
 end

--- a/src/Proc/CubeIO.jl
+++ b/src/Proc/CubeIO.jl
@@ -93,7 +93,10 @@ function exportcube(r::AbstractCubeData,filename::String;priorities = Dict("LON"
   file = NetCDF.create(filename,vars)
   for d in dims
     ncwrite(d.vals,filename,d.name)
+    ncputatt(filename, d.name, Dict("grid_mapping" => "transverse_mercator"))
   end
+  ncputatt(filename, "transverse_mercator", projection)
+  println("CRS added")
   dl = map(i->i.dimlen,dims) |> cumprod
   isplit = findfirst(i->i>5e7,dl)
   isplit isa Nothing && (isplit=length(dl)+1)
@@ -116,4 +119,33 @@ function saveCube(c::AbstractCubeData, name::AbstractString)
 end
 
 export exportcube
+
+global const projection = Dict(
+"grid_mapping_name" => "transverse_mercator",
+"longitude_of_central_meridian" => -9. ,
+"false_easting" => 500000. ,
+"false_northing" => 0. ,
+"latitude_of_projection_origin" => 0. ,
+"scale_factor_at_central_meridian" => 0.9996,
+"long_name" => "CRS definition",
+"longitude_of_prime_meridian" => 0.,
+"semi_major_axis" => 6378137.,
+"inverse_flattening" => 298.257223563 ,
+"spatial_ref" => "PROJCS[\"WGS 84 / UTM zone 29N\",GEOGCS[\"WGS 84\",
+DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,
+AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],
+PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],
+UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],
+AUTHORITY[\"EPSG\",\"4326\"]],
+PROJECTION[\"Transverse_Mercator\"],
+PARAMETER[\"latitude_of_origin\",0],
+PARAMETER[\"central_meridian\",-9],
+PARAMETER[\"scale_factor\",0.9996],
+PARAMETER[\"false_easting\",500000],
+PARAMETER[\"false_northing\",0],
+UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],
+AXIS[\"Easting\",EAST],
+AXIS[\"Northing\",NORTH],
+AUTHORITY[\"EPSG\",\"32629\"]]",
+"GeoTransform" => "722576.2320803495 20 0 4115483.464603715 0 -20 ")
 end


### PR DESCRIPTION
This will add a proj keyword to the exportcube function, so that the generated netCDF file will have crs information. 
I am not happy, that the user would have to add a Dictonary with all of the CRS information, either this should be generated internally from a WKT or Proj string or the CRS information should be included into the metadata of the cube. 
