### PR TITLE
Experimental function to construct an ESDLArray from envistacks

### DIFF
--- a/src/Cubes/GDALCubes.jl
+++ b/src/Cubes/GDALCubes.jl
@@ -1,0 +1,24 @@
+#This is a work in progress implementation of data cubes based on the disk array interface of ARchGDAL.
+
+function gdalcube(path)
+    # Open the data in path as a AG.RasterDataset, which implements the diskarray interface
+    data=AG.read(path)
+    dataset=AG.RasterDataset(data)
+    #Get the geodata of the dataset,
+    geo=AG.getgeotransform(dataset.ds)
+
+    # Compute the latitude and longitude ranges of the data
+    latr = range(geo[1],length=AG.width(dataset), step=geo[2])
+    # This is most likely false, I would have to check which of the entries of geo to use
+    # This only works, because my test data was quadratic.
+    lonr = range(geo[4],length=AG.height(dataset), step=geo[6])
+
+    # Construct actual Axes from the ranges
+    lat = LatAxis(latr)
+    lon = LonAxis(lonr)
+    # Construct a Band axis, for the third dimension
+    # This would need a method to incorporate the bandnames for parsing of the information later on.
+    bandax = CategoricalAxis(:Band, 1:AG.nraster(dataset.ds))
+    #Construct the ESDLArray from the dataset
+    cube=ESDL.Cubes.ESDLArray([lat,lon, bandax], dataset)
+end


### PR DESCRIPTION
This is only as a first start of the discussion, it is not at all 
polished and simply, so that we would construct the needed axes of the 
data to check whether it is working at all.
I can construct an ESDLArray with this, but the computation fails:
```julia
ERROR: MethodError: no method matching read!(::ArchGDAL.IDataset, ::PermutedDimsArray{Float32,3,(2, 3, 1),(3, 1, 2),Array{Float32,3}}, ::Array{Int32,1}, ::Int64, ::Int64, ::Int64, ::Int64)
Closest candidates are:
  read!(::ArchGDAL.AbstractDataset, ::Array{#s58,3} where #s58<:Real, ::Array{Int32,1}, ::Integer, ::Integer, ::Integer, ::Integer) at /home/crem_fe/.julia/dev/ArchGDAL/src/raster/rasterio.jl:244
  read!(::ArchGDAL.AbstractDataset, ::Array{#s58,2} where #s58<:Real, ::Integer, ::Integer, ::Integer, ::Integer, ::Integer) at /home/crem_fe/.julia/dev/ArchGDAL/src/raster/rasterio.jl:231
  read!(::ArchGDAL.AbstractRasterBand, ::Array{#s58,2} where #s58<:Real, ::Integer, ::Integer, ::Integer, ::Integer) at /home/crem_fe/.julia/dev/ArchGDAL/src/raster/rasterio.jl:135
  ...
Stacktrace:
 [1] readblock!(::ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset}, ::PermutedDimsArray{Float32,3,(2, 3, 1),(3, 1, 2),Array{Float32,3}}, ::UnitRange{Int64}, ::UnitRange{Int64}, ::UnitRange{Int64}) at /home/crem_fe/.julia/dev/ArchGDAL/src/raster/array.jl:84
 [2] readblock!(::DiskArrays.PermutedDiskArray{Float32,3,PermutedDimsArray{Float32,3,(3, 1, 2),(2, 3, 1),ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset}}}, ::Array{Float32,3}, ::UnitRange{Int64}, ::UnitRange{Int64}, ::UnitRange{Int64}) at /home/crem_fe/.julia/dev/DiskArrays/src/permute_reshape.jl:80
 [3] getindex_disk(::DiskArrays.PermutedDiskArray{Float32,3,PermutedDimsArray{Float32,3,(3, 1, 2),(2, 3, 1),ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset}}}, ::UnitRange{Int64}, ::Vararg{UnitRange{Int64},N} where N) at /home/crem_fe/.julia/dev/DiskArrays/src/DiskArrays.jl:36
 [4] getindex(::DiskArrays.PermutedDiskArray{Float32,3,PermutedDimsArray{Float32,3,(3, 1, 2),(2, 3, 1),ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset}}}, ::UnitRange{Int64}, ::UnitRange{Int64}, ::UnitRange{Int64}) at /home/crem_fe/.julia/dev/DiskArrays/src/DiskArrays.jl:158
 [5] updatear(::Symbol, ::Tuple{UnitRange{Int64},UnitRange{Int64}}, ::ESDL.Cubes.ESDLArray{Float32,3,DiskArrays.PermutedDiskArray{Float32,3,PermutedDimsArray{Float32,3,(3, 1, 2),(2, 3, 1),ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset}}},Array{CubeAxis,1}}, ::Int64, ::Array{Int64,1}, ::Array{Float32,3}) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:334
 [6] (::ESDL.DAT.var"#54#55"{Tuple{UnitRange{Int64},UnitRange{Int64}},Symbol})(::ESDL.DAT.InputCube{3}) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:319
 [7] foreach at ./abstractarray.jl:1920 [inlined]
 [8] updatears(::Tuple{ESDL.DAT.InputCube{3}}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}, ::Symbol) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:318
 [9] updateinars(::ESDL.DAT.DATConfig{1,1}, ::Tuple{UnitRange{Int64},UnitRange{Int64}}) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:340
 [10] runLoopArgs(::ESDL.DAT.DATConfig{1,1}, ::Tuple{ESDL.DAT.var"#50#52"{ESDL.DAT.var"#50#51#53"{typeof(mean)}},Tuple{Array{Float32,3}},Tuple{Array{Union{Missing, Float32},2}},Tuple{ESDL.ESDLTools.PickAxisArray{Float32,2,Array{Float32,3},(1, 2),1}},Tuple{ESDL.ESDLTools.PickAxisArray{Union{Missing, Float32},2,Array{Union{Missing, Float32},2},(1, 2),0}},Tuple{Tuple{ESDL.DAT.AllMissing}},Tuple{Array{Array{Float32,1},1}},Tuple{Array{Array{Union{Missing, Float32},0},1}},ESDL.DAT.NoLoopAxes,Tuple{},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}}, ::Base.Iterators.ProductIterator{Tuple{Array{UnitRange{Int64},1},Array{UnitRange{Int64},1}}}, ::Bool) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:412
 [11] runLoop(::ESDL.DAT.DATConfig{1,1}, ::Base.Iterators.ProductIterator{Tuple{Array{UnitRange{Int64},1},Array{UnitRange{Int64},1}}}, ::Bool) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:406
 [12] runLoop(::ESDL.DAT.DATConfig{1,1}, ::Bool) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:350
 [13] #mapCube#43(::Float64, ::InDims, ::OutDims, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Array{Int64,1}, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(mapCube), ::typeof(mean), ::Tuple{ESDL.Cubes.ESDLArray{Float32,3,ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset},Array{CubeAxis,1}}}) at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:272
 [14] (::ESDL.DAT.var"#kw##mapCube")(::NamedTuple{(:indims, :outdims, :inplace),Tuple{InDims,OutDims,Bool}}, ::typeof(mapCube), ::Function, ::Tuple{ESDL.Cubes.ESDLArray{Float32,3,ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset},Array{CubeAxis,1}}}) at ./none:0
 [15] #mapslices#42 at /home/crem_fe/.julia/dev/ESDL/src/DAT/DAT.jl:178 [inlined]
 [16] (::Base.var"#kw##mapslices")(::NamedTuple{(:dims,),Tuple{String}}, ::typeof(mapslices), ::Function, ::ESDL.Cubes.ESDLArray{Float32,3,ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset},Array{CubeAxis,1}}) at ./none:0
 [17] top-level scope at REPL[16]:1
```