### PR TITLE
RFC: Wrap nothing keyword

### DIFF
--- a/src/Proc/Shapes.jl
+++ b/src/Proc/Shapes.jl
@@ -50,6 +50,7 @@ function aggregate_out(allout, highmat, labelsleft,n)
 end
 
 function cubefromshape_fraction(shapepath,lonaxis,lataxis;labelsym=nothing, T=Float64, nincrease=10)
+  @debug "cubefromshapefraction"
   s = (length(lonaxis), length(lataxis))
   outmat = zeros(T,map(i->i*nincrease,s)...)
   lon1,lon2 = get_bb(lonaxis)
@@ -73,13 +74,16 @@ function cubefromshape_fraction(shapepath,lonaxis,lataxis;labelsym=nothing, T=Fl
 
 
 end
-function cubefromshape_single(shapepath, lonaxis, lataxis; labelsym = nothing, T=Int32)
+function cubefromshape_single(shapepath, lonaxis, lataxis; labelsym = nothing, T=Int32, kwargs...)
   s = (length(lonaxis), length(lataxis))
   outmat = zeros(T,s...)
+  @debug s
+  @debug kwargs
   lon1,lon2 = get_bb(lonaxis)
   lat1,lat2 = get_bb(lataxis)
-  rasterize!(outmat, shapepath, bb = (left = lon1, right=lon2, top=lat1, bottom=lat2))
-
+  @debug lon1, lon2
+  @debug lat1, lat2
+  rasterize!(outmat, shapepath, bb = (left = lon1, right=lon2, top=lat1, bottom=lat2); kwargs...)
   outmat = replace(outmat,zero(T)=>missing)
   labelsleft = collect(skipmissing(unique(outmat)))
   properties = getlabeldict(shapepath,labelsym,T,labelsleft)
@@ -98,6 +102,7 @@ resolution and the fraction of area within each polygon will be returned.
 """
 cubefromshape(shapepath, c::AbstractCubeData; kwargs...) = cubefromshape(shapepath, getAxis("Lon",c), getAxis("Lat",c);kwargs...)
 function cubefromshape(args...; samplefactor=nothing, kwargs...)
+  @debug kwargs[:wrap]
   if samplefactor===nothing
     cubefromshape_single(args...; kwargs...)
   else
@@ -118,67 +123,91 @@ stripc0x(a) = replace(a, r"[^\x20-\x7e]"=> "")
 
 function rasterize!(outar,shapefile;bb = (left = -180.0, right=180.0, top=90.0,bottom=-90.0),label=nothing)
   shapepath = shapefile
+function rasterize!(outar,shapepath;bb = (left = -180.0, right=180.0, top=90.0,bottom=-90.0),label=nothing, kwargs...)
   t = Shapefile.Table(shapepath)
   p = Shapefile.shapes(t)
+  @debug p
+  @debug kwargs
   if length(p)>1
-    rasterizepoly!(outar,p,bb)
+    @debug length(p)
+    rasterizepoly!(outar,p,bb; kwargs...)
   else
-    rasterizepoly!(outar,p[1],bb)
+    rasterizepoly!(outar,p[1],bb;kwargs...)
   end
 end
 
-function rasterizepoly!(outmat,poly::Vector{<:Union{Missing,AbstractMultiPolygon}},bb)
+function rasterizepoly!(outmat,poly::Vector{<:Union{Missing,AbstractMultiPolygon}},bb;wrap = (left = -180.0,right = 180.0))
     foreach(1:length(poly)) do ipoly
-        rasterizepoly!(outmat,poly[ipoly],bb,value=ipoly)
+      @debug ipoly
+        rasterizepoly!(outmat,poly[ipoly],bb,value=ipoly, wrap=wrap)
     end
     outmat
 end
 
 function rasterizepoly!(outmat,poly::Vector{T},bb;value=one(eltype(outmat)), wrap = (left = -180.0,right = 180.0)) where T<:AbstractPoint
 nx,ny = size(outmat)
+@debug wrap
+@debug nx, ny
+@debug bb
 resx = (bb.right-bb.left)/nx
 resy = (bb.top-bb.bottom)/ny
+@debug resx, resy
+@debug bb.left
 xr = range(bb.left+resx/2,bb.right-resx/2,length=nx)
 yr = range(bb.top-resy/2,bb.bottom+resy/2,length=ny)
-wrapwidth = wrap.right-wrap.left
-
+@debug xr, yr
 for (iy,pixelY) in enumerate(yr)
+
     nodeX = Float64[]
     j = length(poly)
     for i = 1:length(poly)
         p1 = poly[i]
         p2 = poly[j]
-        if wrap !==nothing && abs(p1.x-p2.x)>wrapwidth
+        if wrap !==nothing
+          wrapwidth = wrap.right-wrap.left
+          @debug wrapwidth
+          if abs(p1.x-p2.x)>wrapwidth
             p1,p2 = p1.x < p2.x ? (T(p1.x+wrapwidth,p1.y),T(p2.x,p2.y)) : (T(p1.x,p1.y),T(p2.x+wrapwidth,p2.y))
+            @debug p1, p2
+          end
         end
         if (p1.y < pixelY) && (p2.y >= pixelY) || (p2.y < pixelY) && (p1.y >= pixelY)
+            @debug nodeX, pixelY
             push!(nodeX, p1.x + (pixelY-p1.y)/(p2.y-p1.y)*(p2.x-p1.x))
         end
         j = i
     end
     #Add intersect points at start and end for wrapped polygons
     if wrap!==nothing && any(i->i>wrap.right,nodeX)
+      wrapwidth = wrap.right-wrap.left
+      @debug wrap.left
+      @debug nodeX
         push!(nodeX,wrap.left)
         push!(nodeX,wrap.right)
         map!(i->i>wrap.right ? i-wrapwidth : i,nodeX,nodeX)
     end
+    #@debug nodeX
     sort!(nodeX)
     @assert(iseven(length(nodeX)))
+    #@debug nodeX
     for i = 1:2:length(nodeX)
+      @debug nodeX
+        @debug searchsortedfirst(xr, nodeX[i]), searchsortedlast(xr, nodeX[i+1])
+        @debug iy
         outmat[searchsortedfirst(xr,nodeX[i]):searchsortedlast(xr,nodeX[i+1]),iy].=value
     end
 end
     outmat
 end
 
-function rasterizepoly!(outmat,pp::Shapefile.Polygon,bb;value=one(eltype(outmat)))
+function rasterizepoly!(outmat,pp::Shapefile.Polygon,bb;value=one(eltype(outmat)), kwargs...)
     points = map(1:length(pp.parts)) do ipart
         i0 = pp.parts[ipart]+1
         iend = ipart == length(pp.parts) ? length(pp.points) : pp.parts[ipart+1]
         pp.points[i0:iend]
     end
     foreach(1:length(points)) do ipoly
-        rasterizepoly!(outmat,points[ipoly],bb,value=value)
+        rasterizepoly!(outmat,points[ipoly],bb,value=value;kwargs...)
     end
     outmat
 end

--- a/src/Proc/Shapes.jl
+++ b/src/Proc/Shapes.jl
@@ -122,15 +122,13 @@ function prune_labels!(c::CubeMem)
 end
 stripc0x(a) = replace(a, r"[^\x20-\x7e]"=> "")
 
-function rasterize!(outar,shapefile;bb = (left = -180.0, right=180.0, top=90.0,bottom=-90.0),label=nothing)
-  shapepath = shapefile
 function rasterize!(outar,shapepath;bb = (left = -180.0, right=180.0, top=90.0,bottom=-90.0),label=nothing, kwargs...)
   t = Shapefile.Table(shapepath)
   p = Shapefile.shapes(t)
-  @debug p
-  @debug kwargs
+  #@debug p
+  #@debug kwargs
   if length(p)>1
-    @debug length(p)
+    #@debug length(p)
     rasterizepoly!(outar,p,bb; kwargs...)
   else
     rasterizepoly!(outar,p[1],bb;kwargs...)
@@ -153,7 +151,7 @@ nx,ny = size(outmat)
 resx = (bb.right-bb.left)/nx
 resy = (bb.top-bb.bottom)/ny
 @debug resx, resy
-@debug bb.left
+#@debug bb.left
 xr = range(bb.left+resx/2,bb.right-resx/2,length=nx)
 yr = range(bb.top-resy/2,bb.bottom+resy/2,length=ny)
 @debug xr, yr
@@ -166,14 +164,14 @@ for (iy,pixelY) in enumerate(yr)
         p2 = poly[j]
         if wrap !==nothing
           wrapwidth = wrap.right-wrap.left
-          @debug wrapwidth
+          #@debug wrapwidth
           if abs(p1.x-p2.x)>wrapwidth
             p1,p2 = p1.x < p2.x ? (T(p1.x+wrapwidth,p1.y),T(p2.x,p2.y)) : (T(p1.x,p1.y),T(p2.x+wrapwidth,p2.y))
-            @debug p1, p2
+            #@debug p1, p2
           end
         end
         if (p1.y < pixelY) && (p2.y >= pixelY) || (p2.y < pixelY) && (p1.y >= pixelY)
-            @debug nodeX, pixelY
+            #@debug nodeX, pixelY
             push!(nodeX, p1.x + (pixelY-p1.y)/(p2.y-p1.y)*(p2.x-p1.x))
         end
         j = i
@@ -181,8 +179,8 @@ for (iy,pixelY) in enumerate(yr)
     #Add intersect points at start and end for wrapped polygons
     if wrap!==nothing && any(i->i>wrap.right,nodeX)
       wrapwidth = wrap.right-wrap.left
-      @debug wrap.left
-      @debug nodeX
+      #@debug wrap.left
+      #@debug nodeX
         push!(nodeX,wrap.left)
         push!(nodeX,wrap.right)
         map!(i->i>wrap.right ? i-wrapwidth : i,nodeX,nodeX)
@@ -192,9 +190,9 @@ for (iy,pixelY) in enumerate(yr)
     @assert(iseven(length(nodeX)))
     #@debug nodeX
     for i = 1:2:length(nodeX)
-      @debug nodeX
-        @debug searchsortedfirst(xr, nodeX[i]), searchsortedlast(xr, nodeX[i+1])
-        @debug iy
+      #@debug nodeX
+        #@debug searchsortedfirst(xr, nodeX[i]), searchsortedlast(xr, nodeX[i+1])
+        #@debug iy
         outmat[searchsortedfirst(xr,nodeX[i]):searchsortedlast(xr,nodeX[i+1]),iy].=value
     end
 end

--- a/src/Proc/Shapes.jl
+++ b/src/Proc/Shapes.jl
@@ -49,17 +49,18 @@ function aggregate_out(allout, highmat, labelsleft,n)
   map!(i->i/(n*n),allout,allout)
 end
 
-function cubefromshape_fraction(shapepath,lonaxis,lataxis;labelsym=nothing, T=Float64, nincrease=10)
+function cubefromshape_fraction(shapepath,lonaxis,lataxis;labelsym=nothing, T=Float64, nincrease=10, kwargs...)
   @debug "cubefromshapefraction"
   s = (length(lonaxis), length(lataxis))
   outmat = zeros(T,map(i->i*nincrease,s)...)
   lon1,lon2 = get_bb(lonaxis)
   lat1,lat2 = get_bb(lataxis)
-  rasterize!(outmat, shapepath, bb = (left = lon1, right=lon2, top=lat1, bottom=lat2))
+  rasterize!(outmat, shapepath, bb = (left = lon1, right=lon2, top=lat1, bottom=lat2); kwargs...)
 
   outmat = replace(outmat,zero(T)=>missing)
   labelsleft = collect(skipmissing(unique(outmat)))
-  pp = getlabeldict(shapepath,labelsym,T,Set(labelsleft))["labels"]
+  pp = getlabeldict(shapepath,labelsym,T,Set(labelsleft))
+
 
   allout = zeros(T,s...,length(labelsleft))
   aggregate_out(allout,outmat,labelsleft,nincrease)

--- a/src/Proc/Shapes.jl
+++ b/src/Proc/Shapes.jl
@@ -93,7 +93,7 @@ function cubefromshape_single(shapepath, lonaxis, lataxis; labelsym = nothing, T
 end
 
 """
-    cubefromshape_single(shapepath, refcube; samplefactor=nothing, labelsym = nothing, T=Int32)
+    cubefromshape(shapepath, refcube; samplefactor=nothing, labelsym = nothing, T=Int32)
 
 This function will read the shapefile at `shapepath` (path to the file with .shp extension), which is required to contain
 a list of polygons. The polygons will be *rasterized* to the same grid and bounding box as the reference data cube `refcube`.


### PR DESCRIPTION
I reverted the old PR, because it failed the tests and didn't work for the cubefromshape_fraction function. 
This is a more polished version. 
The tests are passing, but this is not a meaningful information, because the shape functionality is severly undertested. 
I am currently working on some testcases for the wrap=nothing case, but there is still a gap of 360 meters in my end results, and I am not sure, whether this is from the cubefromshape_function or from the exportcube function. 
Therefore, I would wait with merging this, until I have fully tested this usecase. 
